### PR TITLE
Lib.php tests

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -79,7 +79,6 @@ function digitala_update_instance($moduleinstance, $mform = null) {
     global $DB;
 
     $moduleinstance->timemodified = time();
-    $moduleinstance->id = $moduleinstance->instance;
 
     return $DB->update_record('digitala', $moduleinstance);
 }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -29,7 +29,7 @@ global $CFG;
  * @copyright   2022 Name
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class add_digitala_test extends \advanced_testcase {
+class lib_test extends \advanced_testcase {
 
     /**
      * A test to test testing.
@@ -102,7 +102,7 @@ class add_digitala_test extends \advanced_testcase {
         $passed = digitala_update_instance($digitala);
 
         // Check that the digitala instance update returned true.
-        $this->assertEquals(True, $passed);
+        $this->assertEquals(true, $passed);
     }
 
     /**

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -69,4 +69,54 @@ class add_digitala_test extends \advanced_testcase {
                 'resources' => array('text' => 'Resource text', 'format' => 1),
             ]);
     }
+
+    /**
+     * Test deleting a digitala instance.
+     */
+    public function test_digitala_delete_instance() {
+        global $DB;
+
+        // Get the created digitala course.
+        $course = $this->course;
+
+        $digitala = $this->create_digitala();
+
+        digitala_delete_instance($digitala->course);
+
+        // Check that the digitala course instance was removed.
+        $count = $DB->count_records('digitala', array('id' => $digitala->course));
+        $this->assertEquals(0, $count);
+    }
+
+    /**
+     * Test updating a digitala instance.
+     */
+    public function test_digitala_update_instance() {
+        global $DB;
+
+        // Get the created digitala course.
+        $course = $this->course;
+
+        $digitala = $this->create_digitala();
+
+        $passed = digitala_update_instance($digitala);
+
+        // Check that the digitala instance update returned true.
+        $this->assertEquals(True, $passed);
+    }
+
+    /**
+     * Test digitala file areas dummy function.
+     */
+    public function test_digitala_get_file_areas() {
+        $this->assertEquals(array(), digitala_get_file_areas(null, null, null));
+    }
+
+    /**
+     * Test digitala get file info dummy function.
+     */
+    public function test_digitala_get_file_info() {
+        $this->assertEquals(null, digitala_get_file_info(null, null, null, null, null, null, null, null, null));
+    }
+
 }


### PR DESCRIPTION
Co-authored by @makitzei 

We skipped grade testing since they are not used. digitala_pluginfile function was also skipped as it didn't seem possible to test it with unit tests.