### PR TITLE
Assignment info to Aalto fixes

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -353,12 +353,15 @@ function create_microphone($id) {
  *
  * @param stored_file $file - audio file to be sent for evaluation
  * @param string $assignmenttext - assignment text given for students
+ * @param string $lang - language (fin or sve) chosen for the assignment
+ * @param string $type - type of assignment (readaloud or freeform)
+ * @param string $key - keystring for server communication
  */
-function send_answerrecording_for_evaluation($file, $assignmenttext) {
+function send_answerrecording_for_evaluation($file, $assignmenttext, $lang, $type, $key) {
     $assignmenttextraw = format_string($assignmenttext);
     $c = new curl(array('ignoresecurity' => true));
     $curlurl = 'http://digitalamoodle.aalto.fi:5000';
-    $curladd = '?prompt=' . rawurlencode($assignmenttextraw) . '&lang=fin&task=freeform&key=aalto';
+    $curladd = '?prompt=' . rawurlencode($assignmenttextraw) . '&lang='. $lang . '&task=' . $type . '&key=' . $key;
     $curlparams = array('file' => $file);
     $json = $c->post($curlurl . $curladd, $curlparams);
 
@@ -432,7 +435,14 @@ function save_answerrecording($formdata, $assignment) {
                                                                     $file->get_filearea(), $file->get_itemid(),
                                                                     $file->get_filepath(), $file->get_filename(), true).'<br>';
 
-    $evaluation = send_answerrecording_for_evaluation($file, $assignment->assignmenttext);
+    // Change key to a hidden value later on.
+    $key = 'aalto';
+    $evaluation = send_answerrecording_for_evaluation(
+            $file,
+            $assignment->assignmenttext,
+            $assignment->attemptlang,
+            $assignment->attempttype, $key
+        );
 
     $out;
 

--- a/locallib.php
+++ b/locallib.php
@@ -436,7 +436,7 @@ function save_answerrecording($formdata, $assignment) {
 
     $out;
 
-    if (is_null($evaluation)) {
+    if (!isset(json_decode($evaluation)->prompt)) {
         $out .= 'No evaluation was found. Please return to previous page.';
     } else {
         save_attempt($assignment, $file->get_filename(), json_decode($evaluation));

--- a/renderable.php
+++ b/renderable.php
@@ -84,9 +84,11 @@ class digitala_assignment implements renderable {
      * @param string $username - Username of the current active user
      * @param string $assignmenttext - Assignment text for the assignment
      * @param string $resourcetext - Resource text for the assignment
+     * @param string $attempttype - Choice if the assignment is a readaloud or freeform type
+     * @param string $attemptlang - Choice if the assignment is for fin (Finnish) or sve (Swedish) performance
      */
     public function __construct($instanceid, $contextid, $id = 0, $d = 0, $userid, $username,
-        $assignmenttext = '', $resourcetext = '') {
+        $assignmenttext = '', $resourcetext = '', $attempttype = '', $attemptlang = '') {
         $this->instanceid = $instanceid;
         $this->contextid = $contextid;
         $this->id = $id;
@@ -95,6 +97,8 @@ class digitala_assignment implements renderable {
         $this->username = $username;
         $this->assignmenttext = $assignmenttext;
         $this->resourcetext = $resourcetext;
+        $this->attempttype = $attempttype;
+        $this->attemptlang = $attemptlang;
         $this->form = new answerrecording_form($id, $d, 1);
     }
 }

--- a/view.php
+++ b/view.php
@@ -94,7 +94,8 @@ if ($pagenum == 0) {
     $content .= $OUTPUT->render(new digitala_info($id, $d));
 } else if ($pagenum == 1) {
     $content .= $OUTPUT->render(new digitala_assignment($moduleinstance->id, $modulecontext->id, $id, $d,
-                                $USER->id, $USER->username, $moduleinstance->assignment, $moduleinstance->resources));
+                                $USER->id, $USER->username, $moduleinstance->assignment, $moduleinstance->resources,
+                                $moduleinstance->attempttype, $moduleinstance->attemptlang));
 } else {
     $content .= $OUTPUT->render(new digitala_report($id, $d, $reportoutput));
 }


### PR DESCRIPTION
HOX Only problems with code coverage.

Fixes to Aalto server communication:
* check if the Aalto server returns evaluation after assignment submission
* sending actual assignment language and attempt type information to server