### PR TITLE
Readaloud resources to server

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -556,7 +556,6 @@ function save_answerrecording($formdata, $assignment) {
         $texttoaalto = $assignment->resourcetext;
     }
 
-
     $evaluation = send_answerrecording_for_evaluation(
             $file,
             $texttoaalto,

--- a/locallib.php
+++ b/locallib.php
@@ -551,9 +551,15 @@ function save_answerrecording($formdata, $assignment) {
 
     // Change key to a hidden value later on.
     $key = 'aalto';
+    $texttoaalto = $assignment->assignmenttext;
+    if ($assignment->attempttype == 'readaloud') {
+        $texttoaalto = $assignment->resourcetext;
+    }
+
+
     $evaluation = send_answerrecording_for_evaluation(
             $file,
-            $assignment->assignmenttext,
+            $texttoaalto,
             $assignment->attemptlang,
             $assignment->attempttype, $key
         );


### PR DESCRIPTION
Fixing the issue of sending the right text to evaluation server. Now freeform type assignment sends the assignment text and readaloud sends the resource text.