### PR TITLE
FIX: Report feedback links not usable

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -221,17 +221,21 @@ class mod_digitala_renderer extends plugin_renderer_base {
      * @return $out - HTML string to output.
      */
     protected function render_digitala_report_editor(digitala_report_editor $reporteditor) {
+        global $CFG;
+
         $attempt = get_attempt($reporteditor->instanceid, $reporteditor->student);
         $form = new \reporteditor_form($reporteditor->id, $reporteditor->attempttype, $attempt);
 
         $out = '';
 
         if ($form->is_cancelled()) {
-            redirect('/mod/digitala/report.php?id='.$reporteditor->id.'&mode=overview');
+            redirect($CFG->wwwroot.'/mod/digitala/report.php?id='.$reporteditor->id.'&mode=detail&student='
+                     .$reporteditor->student);
         } else if ($fromform = $form->get_data()) {
             // In the future third phase, update evaluation in digitala_attempt here...
             save_report_feedback($reporteditor->attempttype, $fromform, $attempt);
-            redirect('/mod/digitala/report.php?id='.$reporteditor->id.'&mode=overview');
+            redirect($CFG->wwwroot.'/mod/digitala/report.php?id='.$reporteditor->id.'&mode=detail&student='
+                     .$reporteditor->student);
         } else {
             $out = start_container('digitala-report_editor');
             $out .= start_column();

--- a/report.php
+++ b/report.php
@@ -81,7 +81,8 @@ if (has_capability('mod/digitala:viewdetailreport', $modulecontext)) {
         $content .= $OUTPUT->render(new digitala_report($moduleinstance->id, $modulecontext->id, $id, $d,
                                 $moduleinstance->attempttype, $moduleinstance->attemptlang, $moduleinstance->attemptlimit,
                                 $student));
-        $content .= '<a class="btn btn-primary" href="/mod/digitala/reporteditor.php?id='.$id.'&student='.$student.'">'.
+        $content .= '<a class="btn btn-primary" href="'.$CFG->wwwroot
+                    .'/mod/digitala/reporteditor.php?id='.$id.'&student='.$student.'">'.
                     'Give feedback on report</a>';
     } else {
         $content = get_string('results_denied', 'digitala');

--- a/view.php
+++ b/view.php
@@ -80,7 +80,6 @@ $PAGE->requires->js_call_amd('mod_digitala/chart', 'init', array($pagenum));
 
 if ($pagenum == 0) {
     $content .= $OUTPUT->render(new digitala_info($id, $d));
-    $content .= '<a href="/mod/digitala/report.php?id='.$id.'&mode=overview">Overview</a>';
 } else if ($pagenum == 1) {
     $content .= $OUTPUT->render(new digitala_assignment($moduleinstance->id, $modulecontext->id, $USER->id, $USER->username,
                                 $id, $d, $moduleinstance->assignment, $moduleinstance->resources,


### PR DESCRIPTION
This fixes report feedback links to be usable, if Moodle is not in root folder of webserver. Previously for example `https://ohtup-staging.cs.helsinki.fi/digitala/mod/digitala/reporteditor.php` had turned into  `https://ohtup-staging.cs.helsinki.fi/mod/digitala/reporteditor.php`, not anymore with these updates.

Also removed WIP link to overview from `view.php` phase 0.

Changed that report feedback throws into student details after submitting instead of overview.