### PR TITLE
Error handling for attempts hanging in status waiting

### DIFF
--- a/classes/task/check_failed_evaluation.php
+++ b/classes/task/check_failed_evaluation.php
@@ -45,7 +45,7 @@ class check_failed_evaluation extends \core\task\scheduled_task {
      */
     public function execute() {
         global $DB;
-        $time = time()-7200; // Checks if attempt has been waiting for over two hour before re-evaluation.
+        $time = time() - 7200; // Checks if attempt has been waiting for over two hour before re-evaluation.
         $waiting = $DB->get_records_select('digitala_attempts', "status='waiting' AND timemodified < ".$time);
         foreach ($waiting as $attempt) {
             set_attempt_status($attempt, 'retry');

--- a/classes/task/check_failed_evaluation.php
+++ b/classes/task/check_failed_evaluation.php
@@ -45,7 +45,7 @@ class check_failed_evaluation extends \core\task\scheduled_task {
      */
     public function execute() {
         global $DB;
-        $time = time()-3600; // Checks if attempt has been waiting for over one hour before re-evaluation.
+        $time = time()-7200; // Checks if attempt has been waiting for over two hour before re-evaluation.
         $waiting = $DB->get_records_select('digitala_attempts', "status='waiting' AND timemodified < ".$time);
         foreach ($waiting as $attempt) {
             set_attempt_status($attempt, 'retry');

--- a/classes/task/check_failed_evaluation.php
+++ b/classes/task/check_failed_evaluation.php
@@ -45,6 +45,11 @@ class check_failed_evaluation extends \core\task\scheduled_task {
      */
     public function execute() {
         global $DB;
+        $time = time()-3600; // Checks if attempt has been waiting for over one hour before re-evaluation.
+        $waiting = $DB->get_records_select('digitala_attempts', "status='waiting' AND timemodified < ".$time);
+        foreach ($waiting as $attempt) {
+            set_attempt_status($attempt, 'retry');
+        }
 
         $attempts = $DB->get_records('digitala_attempts', array('status' => 'retry'));
 

--- a/tests/behat/assignment.feature
+++ b/tests/behat/assignment.feature
@@ -83,3 +83,24 @@ Feature: Student can see assignment text and resources
     And I run all adhoc tasks
     Then I am on the "Freeform" "mod_digitala > Report" page logged in as "olli"
     Then I should see "Analytic grading"
+
+  Scenario: Attempt in status waiting for over one hour gets re-evaluated
+    When I am on the "Freeform" "mod_digitala > Assignment" page logged in as "olli"
+    And I click on "record" "button"
+    And I wait "6" seconds
+    And I click on "submitModalButton" "button"
+    Then I should see "You still have 2 attempts remaining on this assignment."
+    And I click on "id_submitbutton" "button"
+    Then I should see "Evaluation in progress"
+    And I run the scheduled task "mod_digitala\task\check_failed_evaluation"
+    Then I click on "Press here to check if evaluation is completed." "link"
+    And I should see "Evaluation in progress"
+    Then I set attempts creation time to:
+      | name     | username | time |
+      | Freeform | olli     | 0    |
+    And I run the scheduled task "mod_digitala\task\check_failed_evaluation"
+    Then I click on "Press here to check if evaluation is completed." "link"
+    And I should see "Automated evaluation failed. Evaluation will be runned again in a hour. This could take up to few eternities."
+    And I run all adhoc tasks
+    Then I am on the "Freeform" "mod_digitala > Report" page logged in as "olli"
+    Then I should see "Analytic grading"

--- a/tests/behat/behat_mod_digitala.php
+++ b/tests/behat/behat_mod_digitala.php
@@ -127,6 +127,28 @@ class behat_mod_digitala extends behat_base {
     }
 
     /**
+     * Sets evaluation status in attempt
+     *
+     * @Given /^I set attempts creation time to:$/
+     *
+     * @param TableNode $data
+     */
+    public function i_set_attempts_creation_time_to(TableNode $data) {
+        global $DB;
+
+        foreach ($data->getHash() as $row) {
+            $activity = $DB->get_record('digitala', array('name' => $row['name']), '*', MUST_EXIST);
+            $user = $DB->get_record('user', ['username' => $row['username']], '*', MUST_EXIST);
+
+            $attempt = $DB->get_record('digitala_attempts', array('userid' => $user->id), '*', MUST_EXIST);
+            $attempt->timecreated = $row['time'] == 'now' ? time() : $row['time'];
+            $attempt->timemodified = $row['time'] == 'now' ? time() : $row['time'];
+
+            $DB->update_record('digitala_attempts', $attempt);
+        }
+    }
+
+    /**
      * Checks if given feedback is found from database.
      *
      * @Then /^the following feedback is found:$/

--- a/tests/behat/teacher_report_feedback.feature
+++ b/tests/behat/teacher_report_feedback.feature
@@ -1,4 +1,4 @@
-@mod @mod_digitala @javascript @onlyone
+@mod @mod_digitala @javascript
 Feature: Teacher can give feedback on ASR evaluation
   Student can see given evaluation on the report page
 


### PR DESCRIPTION
If attempt has waited for over two hour, it will be treated as straight evaluation failed when interacting with Aalto.