### PR TITLE
FIX: Check if activity exists when sending to evaluation

### DIFF
--- a/classes/task/check_failed_evaluation.php
+++ b/classes/task/check_failed_evaluation.php
@@ -54,7 +54,7 @@ class check_failed_evaluation extends \core\task\scheduled_task {
         $attempts = $DB->get_records('digitala_attempts', array('status' => 'retry'));
 
         foreach ($attempts as $attempt) {
-            if ($DB->record_exists('digitala', array('id' => $attempt->digitala))){
+            if ($DB->record_exists('digitala', array('id' => $attempt->digitala))) {
                 $activity = $DB->get_record('digitala', array('id' => $attempt->digitala), '*', MUST_EXIST);
                 $course = $DB->get_record('course', array('id' => $activity->course), '*', MUST_EXIST);
                 $cm = get_coursemodule_from_instance('digitala', $activity->id, $course->id, false, MUST_EXIST);

--- a/lang/en/digitala.php
+++ b/lang/en/digitala.php
@@ -201,3 +201,6 @@ $string['teachergrade'] = "Teacher's grade suggestion: ";
 $string['teacherreason'] = "Comments about grade suggestion: ";
 $string['feedback_success'] = 'Comment added successfully to students report.';
 $string['feedback_not-found'] = 'Report for given student is not found';
+
+$string['task-send_to_evaluations'] = 'Send to evaluation';
+$string['task-check_failed_evaluation'] = 'Check for failed evaluations';

--- a/lang/fi/digitala.php
+++ b/lang/fi/digitala.php
@@ -189,3 +189,6 @@ $string['teachergrade'] = "Opettajan arvosanaehdotus: ";
 $string['teacherreason'] = "Kommentti arvosanan muutoksesta: ";
 $string['feedback_success'] = 'Kommentti opiskelijan raportista on tallennettu onnistuneesti.';
 $string['feedback_not-found'] = 'Opiskelijalle ei löydy tuloksia.';
+
+$string['task-send_to_evaluations'] = 'Send to evaluation';
+$string['task-check_failed_evaluation'] = 'Check for failed evaluations';

--- a/lang/sv/digitala.php
+++ b/lang/sv/digitala.php
@@ -189,3 +189,6 @@ $string['teachergrade'] = "Lärarens betygsförslag: ";
 $string['teacherreason'] = "Lärarens kommentar för betygsändring: ";
 $string['feedback_success'] = 'Kommentar till studentrapport sparad framgångsrikt.';
 $string['feedback_not-found'] = 'Inga resultat hittades för studenten.';
+
+$string['task-send_to_evaluations'] = 'Send to evaluation';
+$string['task-check_failed_evaluation'] = 'Check for failed evaluations';


### PR DESCRIPTION
Because there is no cleanup for missing activities attempts.